### PR TITLE
Use Rack Response Object to Handle the Response [finished #113236891]

### DIFF
--- a/lib/pup/application.rb
+++ b/lib/pup/application.rb
@@ -10,9 +10,14 @@ module Pup
       # [200, {}, ["pup: A Ruby Framework for web masters"]]
       # @request = Rack::Request.new(env)
       # @verb, @path = request.request_method, request.path_info
-      controller, action = controller_and_action("my_pages#index")
-      response = controller.new(env).send(action)
-      [200, { "Content-Type" => "text/html" }, [response]]
+      controller_name, action = controller_and_action("my_pages#index")
+      controller = controller_name.new(env)
+      controller.send(action)
+
+      unless controller.get_response
+        controller.render(action)
+      end
+      controller.get_response
     end
 
     def controller_and_action(to)

--- a/lib/pup/dependencies/controller.rb
+++ b/lib/pup/dependencies/controller.rb
@@ -2,7 +2,7 @@ require "erubis"
 
 module Pup
   class Controller
-    attr_reader :request
+    attr_reader :request, :response
 
     def initialize(env)
       @request ||= Rack::Request.new(env)
@@ -12,14 +12,37 @@ module Pup
       request.params
     end
 
-    def render(view_name, locals = {})
+    def make_response(body)
+      @response = Rack::Response.new(body, 200, "Content-Type" => "text/html")
+    end
+
+    def get_response
+      @response
+    end
+
+    def render(*args)
+      response_body = render_template(*args)
+      make_response(response_body)
+    end
+
+    def render_template(view_name, locals = {})
       template = get_template(view_name)
-      Erubis::Eruby.new(template).result(locals)
+      parameters = build_view_params(locals)
+      Erubis::Eruby.new(template).result(parameters)
     end
 
     def get_template(view_name)
       filename = File.join("app", "views", controller_name, "#{view_name}.erb")
       File.read(filename)
+    end
+
+    def build_view_params(locals)
+      vars = {}
+      instance_variables.each do |var|
+        key = var.to_s.delete("@").to_sym
+        vars[key] = instance_variable_get(var)
+      end
+      vars.merge(locals)
     end
 
     def controller_name


### PR DESCRIPTION
Why?
The controller class should build the response using the `Rack::Response` object
How?
Modify the controller class to use the rack response object

https://www.pivotaltracker.com/story/show/113236891
